### PR TITLE
Added CT2 for additional solar system monitoring

### DIFF
--- a/modbus.yaml
+++ b/modbus.yaml
@@ -207,6 +207,16 @@
       scale: 0.001
       precision: 3
       input_type: input
+    - name: "CT2 Meter"
+      scan_interval: 1
+      slave: 247
+      address: 11022
+      state_class: measurement
+      unit_of_measurement: "kW"
+      data_type: int16
+      scale: 0.001
+      precision: 3
+      input_type: input
     - name: "InvTemp"
       scan_interval: 30
       slave: 247


### PR DESCRIPTION
If you have a non-FoxESS solar inverter, by using the additional CT2 port on the com port with a ct sensor you can track the solar generation in one place.