### PR TITLE
Added extra BMS registers to modbusUSB.yaml

### DIFF
--- a/custom_components/HA-FoxESS-Modbus/modbusUSB.yaml
+++ b/custom_components/HA-FoxESS-Modbus/modbusUSB.yaml
@@ -366,8 +366,17 @@
       scan_interval: 60
       slave: 247
       input_type: input
-      device_class: battery
       unit_of_measurement: "Ah"
+      device_class: power
+    - name: "BMS kWh Remaining"
+      address: 11037
+      scan_interval: 60
+      slave: 247
+      input_type: input
+      scale: 0.01
+      precision: 2
+      device_class: battery
+      unit_of_measurement: "kWh"
 
   binary_sensors:
     - name: "Time Period 1 - Enabled"

--- a/custom_components/HA-FoxESS-Modbus/modbusUSB.yaml
+++ b/custom_components/HA-FoxESS-Modbus/modbusUSB.yaml
@@ -1,9 +1,9 @@
+--- # ---------------------------USB/Serial--------------------------------------
 # Created by https://github.com/StealthChesnut/HA-FoxESS-Modbus
 # Modbus Config for Fox ESS Hybrid H1 Inverter
 # Adjust port setting to match USB port in use
 # "slave" setting can be changed on Inverter Menu - Settings, Communication, RS485 but is default to 247 from factory
 
-# ---------------------------USB/Serial--------------------------------------
 - name: FoxESSInverterModbus
   type: serial
   baudrate: 9600
@@ -12,16 +12,16 @@
   parity: N
   port: /dev/ttyUSB0
   stopbits: 1
-# ---------------------------------------------------------------------------
-  
-# ---------------------------WIFI/LAN----------------------------------------
-# If using USR Wifi converter, remove lines 6 through 13 and uncomment the following
-#
-#- name: FoxESSInverterModbus
-#  type: tcp
-#  host: 192.168.XXX.XXX # set to USR devices ip address
-#  port: 502
-# ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------WIFI/LAN----------------------------------------
+  # If using USR Wifi converter, remove lines 6 through 13 and uncomment the following
+  #
+  #- name: FoxESSInverterModbus
+  #  type: tcp
+  #  host: 192.168.XXX.XXX # set to USR devices ip address
+  #  port: 502
+  # ---------------------------------------------------------------------------
 
   sensors:
     - name: "PV1-Voltage"
@@ -44,7 +44,7 @@
       data_type: int16
       scale: 0.1
       precision: 1
-      input_type: input      
+      input_type: input
       device_class: current
     - name: "PV1-Power"
       scan_interval: 5
@@ -55,7 +55,7 @@
       data_type: int16
       scale: 0.001
       precision: 3
-      input_type: input      
+      input_type: input
       device_class: power
     - name: "PV2-Voltage"
       scan_interval: 30
@@ -77,7 +77,7 @@
       data_type: int16
       scale: 0.1
       precision: 1
-      input_type: input      
+      input_type: input
       device_class: current
     - name: "PV2-Power"
       scan_interval: 5
@@ -88,7 +88,7 @@
       data_type: int16
       scale: 0.001
       precision: 3
-      input_type: input  
+      input_type: input
       device_class: power
     - name: "Battery-SoC"
       scan_interval: 30
@@ -119,7 +119,7 @@
       data_type: int16
       scale: 0.001
       precision: 3
-      input_type: input    
+      input_type: input
       device_class: power
     - name: "Load Power"
       scan_interval: 5
@@ -130,7 +130,7 @@
       data_type: int16
       scale: 0.001
       precision: 3
-      input_type: input    
+      input_type: input
       device_class: power
     - name: "InvBatVolt"
       scan_interval: 30
@@ -297,7 +297,78 @@
       scan_interval: 60
       slave: 247
       input_type: input
-      
+
+    - name: "BMS Cell mV High"
+      address: 11045
+      scan_interval: 5
+      slave: 247
+      input_type: input
+      device_class: battery
+      unit_of_measurement: "mV"
+    - name: "BMS Cell mV Low"
+      address: 11046
+      scan_interval: 5
+      slave: 247
+      input_type: input
+      device_class: battery
+      unit_of_measurement: "mV"
+    - name: "BMS Charge Rate"
+      address: 11041
+      scan_interval: 30
+      slave: 247
+      input_type: input
+      device_class: battery
+      unit_of_measurement: "A"
+      scale: 0.1
+    - name: "BMS Discharge Rate"
+      address: 11042
+      scan_interval: 30
+      slave: 247
+      input_type: input
+      device_class: battery
+      unit_of_measurement: "A"
+      scale: 0.1
+    - name: "BMS Cell Temp Low"
+      scan_interval: 30
+      slave: 247
+      address: 11044
+      state_class: measurement
+      unit_of_measurement: "°C"
+      data_type: int16
+      scale: 0.1
+      precision: 1
+      device_class: temperature
+      input_type: input
+    - name: "BMS Cell Temp High"
+      scan_interval: 30
+      slave: 247
+      address: 11043
+      state_class: measurement
+      unit_of_measurement: "°C"
+      data_type: int16
+      scale: 0.1
+      precision: 1
+      device_class: temperature
+      input_type: input
+    - name: "BMS Cell Temp Reported"
+      scan_interval: 30
+      slave: 247
+      address: 11038
+      state_class: measurement
+      unit_of_measurement: "°C"
+      data_type: int16
+      scale: 0.1
+      precision: 1
+      device_class: temperature
+      input_type: input
+    - name: "BMS Watthours Total"
+      address: 11049
+      scan_interval: 60
+      slave: 247
+      input_type: input
+      device_class: battery
+      unit_of_measurement: "Ah"
+
   binary_sensors:
     - name: "Time Period 1 - Enabled"
       address: 41001
@@ -309,5 +380,5 @@
       scan_interval: 60
       slave: 247
       input_type: input
-      
- # !include sensors.yaml
+
+  # !include sensors.yaml


### PR DESCRIPTION
Changes to modbusUSB.yaml add monitoring for BMS cell voltages and temperatures, charge and discharge rates, plus total watthours used. 

All read only modbus requests.


![](https://i.imgur.com/35qSW72.png)
