### PR TITLE
Add unique_ids to configuration.yaml, modbusLAN.yaml, modbusUSB.yaml

### DIFF
--- a/custom_components/HA-FoxESS-Modbus/configuration.yaml
+++ b/custom_components/HA-FoxESS-Modbus/configuration.yaml
@@ -19,54 +19,63 @@ modbus: !include custom_components/HA-FoxESS-Modbus/modbusLAN.yaml
 sensor: 
   - method: left
     name: pv1_sum
+    unique_id: foxess_inv1_pv1_sum
     platform: integration
     round: 2
     source: sensor.pv1_power
     unit_time: h
   - method: left
     name: pv2_sum
+    unique_id: foxess_inv1_pv2_sum
     platform: integration
     round: 2
     source: sensor.pv2_power
     unit_time: h
   - method: left
     name: pv_total_sum
+    unique_id: foxess_inv1_pv_total_sum
     platform: integration
     round: 2
     source: sensor.pv_power_now
     unit_time: h
   - method: left
     name: load_sum
+    unique_id: foxess_inv1_load_sum
     platform: integration
     round: 2
     source: sensor.load_power
     unit_time: h
   - method: left
     name: bat_charge_sum
+    unique_id: foxess_inv1_bat_charge_sum
     platform: integration
     round: 2
     source: sensor.battery_charge
     unit_time: h
   - method: left
     name: bat_discharge_sum
+    unique_id: foxess_inv1_bat_discharge_sum
     platform: integration
     round: 2
     source: sensor.battery_discharge
     unit_time: h
   - method: left
     name: feedin_sum
+    unique_id: foxess_inv1_feedin_sum
     platform: integration
     round: 2
     source: sensor.feed_in_power
     unit_time: h
   - method: left
     name: grid_consumption_sum
+    unique_id: foxess_inv1_grid_consumption_sum
     platform: integration
     round: 2
     source: sensor.grid_consumption
     unit_time: h
   - platform: integration
     name: losses_sum
+    unique_id: foxess_inv1_losses_sum
     source: sensor.system_losses
     unit_time: h
     method: left
@@ -76,6 +85,7 @@ sensor:
 template:
   - sensor:
       - name: "Battery Discharge"
+        unique_id: foxess_inv1_battery_discharge
         device_class: "power"
         unit_of_measurement: "kW"
         state: >
@@ -85,6 +95,7 @@ template:
             0 
             {% endif %}
       - name: "Battery Charge"
+        unique_id: foxess_inv1_battery_charge
         device_class: "power"
         unit_of_measurement: "kW"
         state: >
@@ -94,6 +105,7 @@ template:
             0 
             {% endif %}
       - name: "Feed In Power"
+        unique_id: foxess_inv1_feed_in_power
         device_class: "power"
         unit_of_measurement: "kW"
         state: >
@@ -103,6 +115,7 @@ template:
             0 
             {% endif %}
       - name: "Grid Consumption"
+        unique_id: foxess_inv1_grid_consumption
         device_class: "power"
         unit_of_measurement: "kW"
         state: >
@@ -112,16 +125,19 @@ template:
             0 
             {% endif %}
       - name: "PV Power Now"
+        unique_id: foxess_inv1_pv_power_now
         device_class: "power"
         unit_of_measurement: "kW"
         state: >
               {{ (states('sensor.pv1_power') | float(default=0) + states('sensor.pv2_power') | float(default=0) ) * 1 }}
       - name: "PV Energy Daily"
+        unique_id: foxess_inv1_pv_energy_daily
         device_class: "energy"
         unit_of_measurement: "kWh"
         state: >
               {{ ((states('sensor.pv1_daily') | float(default=0) + states('sensor.pv2_daily') | float(default=0) ) * 1 ) | round(2) }} 
       - name: "System Losses"
+        unique_id: foxess_inv1_system_losses
         device_class: "power"
         unit_of_measurement: "kW"
         state: >
@@ -133,6 +149,7 @@ template:
                - states('sensor.feed_in_power') | float(default=0)
                - states('sensor.load_power') | float(default=0) )) | round(2) }}
       - name: "Time Period 1 - Start Time"
+        unique_id: foxess_inv1_time_period_1_start_time
         icon: "mdi:calendar-clock"
         state: >
           {% set raw_time = states('sensor.time_period_1_start') | int %}
@@ -140,6 +157,7 @@ template:
           {% set minutes = raw_time - (hours * 256) %}
           {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
       - name: "Time Period 1 - End Time"
+        unique_id: foxess_inv1_time_period_1_end_time
         icon: "mdi:calendar-clock"
         state: >
           {% set raw_time = states('sensor.time_period_1_end') | int %}
@@ -147,6 +165,7 @@ template:
           {% set minutes = raw_time - (hours * 256) %}
           {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
       - name: "Time Period 2 - Start Time"
+        unique_id: foxess_inv1_time_period_2_start_time
         icon: "mdi:calendar-clock"
         state: >
           {% set raw_time = states('sensor.time_period_2_start') | int %}
@@ -154,6 +173,7 @@ template:
           {% set minutes = raw_time - (hours * 256) %}
           {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
       - name: "Time Period 2 - End Time"
+        unique_id: foxess_inv1_time_period_2_end_time
         icon: "mdi:calendar-clock"
         state: >
           {% set raw_time = states('sensor.time_period_2_end') | int %}
@@ -164,26 +184,34 @@ template:
 # Utility Meters - Provides meters to be used with the energy dashboard and reset daily
 utility_meter:
   load_daily:
+    unique_id: foxess_inv1_load_daily
     source: sensor.load_sum
     cycle: daily
   pv1_daily:
+    unique_id: foxess_inv1_pv1_daily
     source: sensor.pv1_sum
     cycle: daily
   pv2_daily:
+    unique_id: foxess_inv1_pv2_daily
     source: sensor.pv2_sum
     cycle: daily
   bat_charge_daily:
+    unique_id: foxess_inv1_bat_charge_daily
     source: sensor.bat_charge_sum
     cycle: daily
   bat_discharge_daily:
+    unique_id: foxess_inv1_bat_discharge_daily
     source: sensor.bat_discharge_sum
     cycle: daily
   feedin_daily:
+    unique_id: foxess_inv1_feedin_daily
     source: sensor.feedin_sum
     cycle: daily
   grid_daily:
+    unique_id: foxess_inv1_grid_daily
     source: sensor.grid_consumption_sum
     cycle: daily
   losses_daily:
+    unique_id: foxess_inv1_losses_daily
     source: sensor.losses_sum
     cycle: daily

--- a/custom_components/HA-FoxESS-Modbus/configuration.yaml
+++ b/custom_components/HA-FoxESS-Modbus/configuration.yaml
@@ -84,102 +84,102 @@ sensor:
  #Templates enable math operations against states/values to give us better data
 template:
   - sensor:
-      - name: "Battery Discharge"
-        unique_id: foxess_inv1_battery_discharge
-        device_class: "power"
-        unit_of_measurement: "kW"
-        state: >
-            {% if (states('sensor.battery_discharge_power') | float(default=0) ) > 0 %}
-            {{ states('sensor.battery_discharge_power') | float(default=0) * 1 }}
-            {% else %}
-            0 
-            {% endif %}
-      - name: "Battery Charge"
-        unique_id: foxess_inv1_battery_charge
-        device_class: "power"
-        unit_of_measurement: "kW"
-        state: >
-            {% if (states('sensor.battery_discharge_power') | float(default=0) ) < 0 %}
-            {{ states('sensor.battery_discharge_power') | float(default=0) * -1 }}
-            {% else %}
-            0 
-            {% endif %}
-      - name: "Feed In Power"
-        unique_id: foxess_inv1_feed_in_power
-        device_class: "power"
-        unit_of_measurement: "kW"
-        state: >
-            {% if (states('sensor.grid_ct') | float(default=0) ) > 0 %}
-            {{ states('sensor.grid_ct') | float(default=0) * 1 }}
-            {% else %}
-            0 
-            {% endif %}
-      - name: "Grid Consumption"
-        unique_id: foxess_inv1_grid_consumption
-        device_class: "power"
-        unit_of_measurement: "kW"
-        state: >
-            {% if (states('sensor.grid_ct') | float(default=0) ) < 0 %}
-            {{ states('sensor.grid_ct') | float(default=0) * -1 }}
-            {% else %}
-            0 
-            {% endif %}
-      - name: "PV Power Now"
-        unique_id: foxess_inv1_pv_power_now
-        device_class: "power"
-        unit_of_measurement: "kW"
-        state: >
-              {{ (states('sensor.pv1_power') | float(default=0) + states('sensor.pv2_power') | float(default=0) ) * 1 }}
-      - name: "PV Energy Daily"
-        unique_id: foxess_inv1_pv_energy_daily
-        device_class: "energy"
-        unit_of_measurement: "kWh"
-        state: >
-              {{ ((states('sensor.pv1_daily') | float(default=0) + states('sensor.pv2_daily') | float(default=0) ) * 1 ) | round(2) }} 
-      - name: "System Losses"
-        unique_id: foxess_inv1_system_losses
-        device_class: "power"
-        unit_of_measurement: "kW"
-        state: >
-               {{ ((states('sensor.pv1_power') | float(default=0)
-               + states('sensor.pv2_power') | float(default=0)
-               + states('sensor.grid_consumption') | float(default=0)
-               + states('sensor.battery_discharge') | float(default=0)
-               - states('sensor.battery_charge') | float(default=0)
-               - states('sensor.feed_in_power') | float(default=0)
-               - states('sensor.load_power') | float(default=0) )) | round(2) }}
-      - name: "Time Period 1 - Start Time"
-        unique_id: foxess_inv1_time_period_1_start_time
-        icon: "mdi:calendar-clock"
-        state: >
-          {% set raw_time = states('sensor.time_period_1_start') | int %}
-          {% set hours = raw_time // 256 %}
-          {% set minutes = raw_time - (hours * 256) %}
-          {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
-      - name: "Time Period 1 - End Time"
-        unique_id: foxess_inv1_time_period_1_end_time
-        icon: "mdi:calendar-clock"
-        state: >
-          {% set raw_time = states('sensor.time_period_1_end') | int %}
-          {% set hours = raw_time // 256 %}
-          {% set minutes = raw_time - (hours * 256) %}
-          {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
-      - name: "Time Period 2 - Start Time"
-        unique_id: foxess_inv1_time_period_2_start_time
-        icon: "mdi:calendar-clock"
-        state: >
-          {% set raw_time = states('sensor.time_period_2_start') | int %}
-          {% set hours = raw_time // 256 %}
-          {% set minutes = raw_time - (hours * 256) %}
-          {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
-      - name: "Time Period 2 - End Time"
-        unique_id: foxess_inv1_time_period_2_end_time
-        icon: "mdi:calendar-clock"
-        state: >
-          {% set raw_time = states('sensor.time_period_2_end') | int %}
-          {% set hours = raw_time // 256 %}
-          {% set minutes = raw_time - (hours * 256) %}
-          {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
+    - name: "Battery Discharge"
+      unique_id: foxess_inv1_battery_discharge
+      device_class: "power"
+      unit_of_measurement: "kW"
+      state: >
+          {% if (states('sensor.battery_discharge_power') | float(default=0) ) > 0 %}
+          {{ states('sensor.battery_discharge_power') | float(default=0) * 1 }}
+          {% else %}
+          0 
+          {% endif %}
+    - name: "Battery Charge"
+      unique_id: foxess_inv1_battery_charge
+      device_class: "power"
+      unit_of_measurement: "kW"
+      state: >
+          {% if (states('sensor.battery_discharge_power') | float(default=0) ) < 0 %}
+          {{ states('sensor.battery_discharge_power') | float(default=0) * -1 }}
+          {% else %}
+          0 
+          {% endif %}
+    - name: "Feed In Power"
+      unique_id: foxess_inv1_feed_in_power
+      device_class: "power"
+      unit_of_measurement: "kW"
+      state: >
+          {% if (states('sensor.grid_ct') | float(default=0) ) > 0 %}
+          {{ states('sensor.grid_ct') | float(default=0) * 1 }}
+          {% else %}
+          0 
+          {% endif %}
+    - name: "Grid Consumption"
+      unique_id: foxess_inv1_grid_consumption
+      device_class: "power"
+      unit_of_measurement: "kW"
+      state: >
+          {% if (states('sensor.grid_ct') | float(default=0) ) < 0 %}
+          {{ states('sensor.grid_ct') | float(default=0) * -1 }}
+          {% else %}
+          0 
+          {% endif %}
+    - name: "PV Power Now"
+      unique_id: foxess_inv1_pv_power_now
+      device_class: "power"
+      unit_of_measurement: "kW"
+      state: >
+            {{ (states('sensor.pv1_power') | float(default=0) + states('sensor.pv2_power') | float(default=0) ) * 1 }}
+    - name: "PV Energy Daily"
+      unique_id: foxess_inv1_pv_energy_daily
+      device_class: "energy"
+      unit_of_measurement: "kWh"
+      state: >
+            {{ ((states('sensor.pv1_daily') | float(default=0) + states('sensor.pv2_daily') | float(default=0) ) * 1 ) | round(2) }} 
+    - name: "System Losses"
+      unique_id: foxess_inv1_system_losses
+      device_class: "power"
+      unit_of_measurement: "kW"
+      state: >
+             {{ ((states('sensor.pv1_power') | float(default=0)
+             + states('sensor.pv2_power') | float(default=0)
+             + states('sensor.grid_consumption') | float(default=0)
+             + states('sensor.battery_discharge') | float(default=0)
+             - states('sensor.battery_charge') | float(default=0)
+             - states('sensor.feed_in_power') | float(default=0)
+             - states('sensor.load_power') | float(default=0) )) | round(2) }}
+    - name: "Time Period 1 - Start Time"
+      unique_id: foxess_inv1_time_period_1_start_time
+      icon: "mdi:calendar-clock"
+      state: >
+        {% set raw_time = states('sensor.time_period_1_start') | int %}
+        {% set hours = raw_time // 256 %}
+        {% set minutes = raw_time - (hours * 256) %}
+        {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
+    - name: "Time Period 1 - End Time"
+      unique_id: foxess_inv1_time_period_1_end_time
+      icon: "mdi:calendar-clock"
+      state: >
+        {% set raw_time = states('sensor.time_period_1_end') | int %}
+        {% set hours = raw_time // 256 %}
+        {% set minutes = raw_time - (hours * 256) %}
+        {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
+    - name: "Time Period 2 - Start Time"
+      unique_id: foxess_inv1_time_period_2_start_time
+      icon: "mdi:calendar-clock"
+      state: >
+        {% set raw_time = states('sensor.time_period_2_start') | int %}
+        {% set hours = raw_time // 256 %}
+        {% set minutes = raw_time - (hours * 256) %}
+        {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
+    - name: "Time Period 2 - End Time"
+      unique_id: foxess_inv1_time_period_2_end_time
+      icon: "mdi:calendar-clock"
+      state: >
+        {% set raw_time = states('sensor.time_period_2_end') | int %}
+        {% set hours = raw_time // 256 %}
+        {% set minutes = raw_time - (hours * 256) %}
+        {{ strptime(hours | string + ":" + minutes | string, '%H:%M').time() }}
 
 # Utility Meters - Provides meters to be used with the energy dashboard and reset daily
 utility_meter:

--- a/custom_components/HA-FoxESS-Modbus/modbusLAN.yaml
+++ b/custom_components/HA-FoxESS-Modbus/modbusLAN.yaml
@@ -15,6 +15,7 @@
 
   sensors:
     - name: "PV1-Voltage"
+      unique_id: foxess_inv1_pv1_voltage
       scan_interval: 30
       slave: 247
       address: 31000
@@ -26,6 +27,7 @@
       input_type: holding
       device_class: voltage
     - name: "PV1-Current"
+      unique_id: foxess_inv1_pv1_current
       scan_interval: 30
       slave: 247
       address: 31001
@@ -37,6 +39,7 @@
       input_type: holding      
       device_class: current
     - name: "PV1-Power"
+      unique_id: foxess_inv1_pv1_power
       scan_interval: 5
       slave: 247
       address: 31002
@@ -48,6 +51,7 @@
       input_type: holding      
       device_class: power
     - name: "PV2-Voltage"
+      unique_id: foxess_inv1_pv2_voltage
       scan_interval: 30
       slave: 247
       address: 31003
@@ -59,6 +63,7 @@
       input_type: holding
       device_class: voltage
     - name: "PV2-Current"
+      unique_id: foxess_inv1_pv2_current
       scan_interval: 30
       slave: 247
       address: 31004
@@ -70,6 +75,7 @@
       input_type: holding      
       device_class: current
     - name: "PV2-Power"
+      unique_id: foxess_inv1_pv2_power
       scan_interval: 5
       slave: 247
       address: 31005
@@ -82,6 +88,7 @@
       device_class: power
 
     - name: "RVolt" # Grid Voltage
+      unique_id: foxess_inv1_grid_voltage_R
       scan_interval: 30
       slave: 247
       address: 31006
@@ -93,6 +100,7 @@
       input_type: holding
       device_class: voltage
     - name: "RCurrent" # Generated AC Current ?
+      unique_id: foxess_inv1_inv_current_R
       scan_interval: 30
       slave: 247
       address: 31007
@@ -115,6 +123,7 @@
       input_type: holding  
       device_class: power
     - name: "RFreq" # Grid Frequency
+      unique_id: foxess_inv1_grid_frequency
       scan_interval: 30
       slave: 247
       address: 31009
@@ -127,6 +136,7 @@
       device_class: frequency
       
     - name: "Grid CT"
+      unique_id: foxess_inv1_grid_ct
       scan_interval: 5
       address: 31014
       state_class: measurement
@@ -137,6 +147,7 @@
       input_type: holding    
       device_class: power
     - name: "CT2"
+      unique_id: foxess_inv1_ct2
       scan_interval: 5
       address: 31015
       state_class: measurement
@@ -147,6 +158,7 @@
       input_type: holding    
       device_class: power
     - name: "Load Power"
+      unique_id: foxess_inv1_load_power
       scan_interval: 5
       address: 31016
       state_class: measurement
@@ -158,6 +170,7 @@
       device_class: power
     
     - name: "AmbTemp"
+      unique_id: foxess_inv1_ambient_temperature
       scan_interval: 30
       slave: 247
       address: 31018
@@ -169,6 +182,7 @@
       device_class: temperature
       input_type: holding    
     - name: "InvTemp"
+      unique_id: foxess_inv1_inverter_temperature
       scan_interval: 30
       slave: 247
       address: 31019
@@ -183,6 +197,7 @@
 
 
     - name: "BatVolt"
+      unique_id: foxess_inv1_battery_voltage
       scan_interval: 30
       address: 31020
       state_class: measurement
@@ -193,6 +208,7 @@
       device_class: voltage
       input_type: holding
     - name: "BatCurrent"
+      unique_id: foxess_inv1_battery_current
       scan_interval: 30
       address: 31021
       state_class: measurement
@@ -203,6 +219,7 @@
       input_type: holding      
       device_class: current
     - name: "Battery-Discharge-Power"
+      unique_id: foxess_inv1_battery_power
       scan_interval: 5
       slave: 247
       address: 31022
@@ -214,6 +231,7 @@
       input_type: holding    
       device_class: power
     - name: "Battery-Temp"
+      unique_id: foxess_inv1_battery_temperature
       scan_interval: 60
       slave: 247
       address: 31023
@@ -225,6 +243,7 @@
       input_type: holding
       device_class: temperature
     - name: "Battery-SoC"
+      unique_id: foxess_inv1_battery_soc
       scan_interval: 30
       slave: 247
       address: 31024

--- a/custom_components/HA-FoxESS-Modbus/modbusUSB.yaml
+++ b/custom_components/HA-FoxESS-Modbus/modbusUSB.yaml
@@ -25,6 +25,7 @@
 
   sensors:
     - name: "PV1-Voltage"
+      unique_id: foxess_inv1_pv1_voltage
       scan_interval: 30
       slave: 247
       address: 11000
@@ -36,6 +37,7 @@
       input_type: input
       device_class: voltage
     - name: "PV1-Current"
+      unique_id: foxess_inv1_pv1_current
       scan_interval: 30
       slave: 247
       address: 11001
@@ -47,6 +49,7 @@
       input_type: input
       device_class: current
     - name: "PV1-Power"
+      unique_id: foxess_inv1_pv1_power
       scan_interval: 5
       slave: 247
       address: 11002
@@ -58,6 +61,7 @@
       input_type: input
       device_class: power
     - name: "PV2-Voltage"
+      unique_id: foxess_inv1_pv2_voltage
       scan_interval: 30
       slave: 247
       address: 11003
@@ -69,6 +73,7 @@
       input_type: input
       device_class: voltage
     - name: "PV2-Current"
+      unique_id: foxess_inv1_pv2_current
       scan_interval: 30
       slave: 247
       address: 11004
@@ -80,6 +85,7 @@
       input_type: input
       device_class: current
     - name: "PV2-Power"
+      unique_id: foxess_inv1_pv2_power
       scan_interval: 5
       slave: 247
       address: 11005
@@ -91,6 +97,7 @@
       input_type: input
       device_class: power
     - name: "Battery-SoC"
+      unique_id: foxess_inv1_battery_soc
       scan_interval: 30
       slave: 247
       address: 11036
@@ -100,6 +107,7 @@
       input_type: input
       device_class: battery
     - name: "Battery-Temp"
+      unique_id: foxess_inv1_battery_temperature
       scan_interval: 60
       slave: 247
       address: 11038
@@ -111,6 +119,7 @@
       input_type: input
       device_class: temperature
     - name: "Battery-Discharge-Power"
+      unique_id: foxess_inv1_battery_power
       scan_interval: 5
       slave: 247
       address: 11008
@@ -122,6 +131,7 @@
       input_type: input
       device_class: power
     - name: "Load Power"
+      unique_id: foxess_inv1_load_power
       scan_interval: 5
       slave: 247
       address: 11023
@@ -133,6 +143,7 @@
       input_type: input
       device_class: power
     - name: "InvBatVolt"
+      unique_id: foxess_inv1_inverter_battery_voltage
       scan_interval: 30
       slave: 247
       address: 11006
@@ -143,6 +154,7 @@
       precision: 1
       input_type: input
     - name: "InvBatPower"
+      unique_id: foxess_inv1_inverter_battery_power
       scan_interval: 5
       slave: 247
       address: 11007
@@ -153,6 +165,7 @@
       precision: 2
       input_type: input
     - name: "RVolt"
+      unique_id: foxess_inv1_grid_voltage_R
       scan_interval: 30
       slave: 247
       address: 11009
@@ -164,6 +177,7 @@
       input_type: input
       device_class: voltage
     - name: "RCurrent"
+      unique_id: foxess_inv1_inv_current_R
       scan_interval: 30
       slave: 247
       address: 11010
@@ -175,6 +189,7 @@
       input_type: input
       device_class: current
     - name: "RFreq"
+      unique_id: foxess_inv1_grid_frequency
       scan_interval: 30
       slave: 247
       address: 11014
@@ -186,6 +201,7 @@
       input_type: input
       device_class: frequency
     - name: "EPS RVolt"
+      unique_id: foxess_inv1_eps_rvolt
       scan_interval: 30
       slave: 247
       address: 11015
@@ -196,6 +212,7 @@
       precision: 1
       input_type: input
     - name: "Grid CT"
+      unique_id: foxess_inv1_grid_ct
       scan_interval: 5
       slave: 247
       address: 11021
@@ -206,6 +223,7 @@
       precision: 3
       input_type: input
     - name: "CT2 Meter"
+      unique_id: foxess_inv1_ct2
       scan_interval: 1
       slave: 247
       address: 11022
@@ -216,6 +234,7 @@
       precision: 3
       input_type: input
     - name: "InvTemp"
+      unique_id: foxess_inv1_inverter_temperature
       scan_interval: 30
       slave: 247
       address: 11024
@@ -227,6 +246,7 @@
       device_class: temperature
       input_type: input
     - name: "AmbTemp"
+      unique_id: foxess_inv1_ambient_temperature
       scan_interval: 30
       slave: 247
       address: 11025
@@ -238,6 +258,7 @@
       device_class: temperature
       input_type: input
     - name: "BatVolt"
+      unique_id: foxess_inv1_battery_voltage
       scan_interval: 30
       slave: 247
       address: 11034
@@ -249,6 +270,7 @@
       device_class: voltage
       input_type: input
     - name: "Temp"
+      unique_id: foxess_inv1_temperature
       scan_interval: 30
       slave: 247
       address: 11035
@@ -260,6 +282,7 @@
       device_class: temperature
       input_type: input
     - name: "Min SoC"
+      unique_id: foxess_inv1_min_soc
       scan_interval: 60
       slave: 247
       address: 41009
@@ -269,6 +292,7 @@
       input_type: input
       device_class: battery
     - name: "Min SoC (On Grid)"
+      unique_id: foxess_inv1_min_soc_on_grid
       scan_interval: 60
       slave: 247
       address: 41011
@@ -278,27 +302,32 @@
       input_type: input
       device_class: battery
     - name: "Time Period 1 - Start"
+      unique_id: foxess_inv1_time_period_1_start
       address: 41002
       scan_interval: 60
       slave: 247
       input_type: input
     - name: "Time Period 1 - End"
+      unique_id: foxess_inv1_time_period_1_end
       address: 41003
       scan_interval: 60
       slave: 247
       input_type: input
     - name: "Time Period 2 - Start"
+      unique_id: foxess_inv1_time_period_2_start
       address: 41005
       scan_interval: 60
       slave: 247
       input_type: input
     - name: "Time Period 2 - End"
+      unique_id: foxess_inv1_time_period_2_end
       address: 41006
       scan_interval: 60
       slave: 247
       input_type: input
 
     - name: "BMS Cell mV High"
+      unique_id: foxess_inv1_bms_cell_mv_high
       address: 11045
       scan_interval: 5
       slave: 247
@@ -306,6 +335,7 @@
       device_class: voltage
       unit_of_measurement: "mV"
     - name: "BMS Cell mV Low"
+      unique_id: foxess_inv1_bms_cell_low
       address: 11046
       scan_interval: 5
       slave: 247
@@ -313,6 +343,7 @@
       device_class: voltage
       unit_of_measurement: "mV"
     - name: "BMS Charge Rate"
+      unique_id: foxess_inv1_bms_charge_rate
       address: 11041
       scan_interval: 30
       slave: 247
@@ -321,6 +352,7 @@
       unit_of_measurement: "A"
       scale: 0.1
     - name: "BMS Discharge Rate"
+      unique_id: foxess_inv1_bms_discharge_rate
       address: 11042
       scan_interval: 30
       slave: 247
@@ -329,6 +361,7 @@
       unit_of_measurement: "A"
       scale: 0.1
     - name: "BMS Cell Temp Low"
+      unique_id: foxess_inv1_bms_cell_temperature_low
       scan_interval: 30
       slave: 247
       address: 11044
@@ -340,6 +373,7 @@
       device_class: temperature
       input_type: input
     - name: "BMS Cell Temp High"
+      unique_id: foxess_inv1_bms_cell_temperature_high
       scan_interval: 30
       slave: 247
       address: 11043
@@ -351,6 +385,7 @@
       device_class: temperature
       input_type: input
     - name: "BMS Watthours Total"
+      unique_id: foxess_inv1_bms_watthours_total
       address: 11049
       scan_interval: 60
       slave: 247
@@ -358,6 +393,7 @@
       unit_of_measurement: "Ah"
       device_class: energy
     - name: "BMS kWh Remaining"
+      unique_id: foxess_inv1_bms_kwh_remaining
       address: 11037
       scan_interval: 60
       slave: 247
@@ -369,11 +405,13 @@
 
   binary_sensors:
     - name: "Time Period 1 - Enabled"
+      unique_id: foxess_inv1_time_period_1_enabled
       address: 41001
       scan_interval: 60
       slave: 247
       input_type: input
     - name: "Time Period 2 - Enabled"
+      unique_id: foxess_inv1_time_period_2_enabled
       address: 41004
       scan_interval: 60
       slave: 247


### PR DESCRIPTION
 I've tried to match the unique_ids already present in modbus-H3-LAN.yaml and modbus-H3-USB.yaml where I could figure them out, but I might have mis-matched some.

Also fix some indentation in configuration.yaml. I suggest reviewing just the first commit -- that commit is only whitespace changes.